### PR TITLE
Fix e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+- Change default grafana images to use GS-retagged ones
+
 ## [8.1.3] - 2024-01-25
 
 ### Changed

--- a/helm/kube-prometheus-stack/values.yaml
+++ b/helm/kube-prometheus-stack/values.yaml
@@ -43,11 +43,16 @@ kube-prometheus-stack:
         sourceLabels:
         - __name__
   grafana:
+    image:
+      repository: "giantswarm/grafana"
     rbac:
       pspEnabled: true
       pspUseAppArmor: false
     ingress:
       ingressClassName: nginx
+    sidecar:
+      image:
+        repository: "giantswarm/k8s-sidecar"
   kubeApiServer:
     enabled: true
     serviceMonitor:


### PR DESCRIPTION
e2e tests were broken because it tried to pull images for grafana that do not exist on our registries.