### PR TITLE
fix-ksm-config

### DIFF
--- a/helm/kube-prometheus-stack/values.yaml
+++ b/helm/kube-prometheus-stack/values.yaml
@@ -213,42 +213,15 @@ kube-prometheus-stack:
   kubeStateMetrics:
     enabled: true
   kube-state-metrics:
-    # Enabling verticalpodautoscaler collector until 2.9.0.
-    collectors:
-    - certificatesigningrequests
-    - configmaps
-    - cronjobs
-    - daemonsets
-    - deployments
-    - endpoints
-    - horizontalpodautoscalers
-    - ingresses
-    - jobs
-    - leases
-    - limitranges
-    - mutatingwebhookconfigurations
-    - namespaces
-    - networkpolicies
-    - nodes
-    - persistentvolumeclaims
-    - persistentvolumes
-    - poddisruptionbudgets
-    - pods
-    - replicasets
-    - replicationcontrollers
-    - resourcequotas
-    - secrets
-    - services
-    - statefulsets
-    - storageclasses
-    - validatingwebhookconfigurations
-    - volumeattachments
     image:
       repository: giantswarm/kube-state-metrics
     metricLabelsAllowlist:
+    - cronjobs=[application.giantswarm.io/team, app.kubernetes.io/name]
+    - jobs=[application.giantswarm.io/team, app.kubernetes.io/name]
     - daemonsets=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, giantswarm.io/monitoring_basic_sli, giantswarm.io/service-type]
     - deployments=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, giantswarm.io/monitoring_basic_sli, giantswarm.io/service-type]
     - nodes=[giantswarm.io/machine-pool, giantswarm.io/machine-deployment, ip, node.kubernetes.io/instance-type, topology.kubernetes.io/region, topology.kubernetes.io/zone]
+    - persistentvolumeclaims=[name]
     - pods=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, giantswarm.io/monitoring_basic_sli, giantswarm.io/service-type]
     - statefulsets=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, giantswarm.io/monitoring_basic_sli, giantswarm.io/service-type]
     networkPolicy:

--- a/helm/kube-prometheus-stack/values.yaml
+++ b/helm/kube-prometheus-stack/values.yaml
@@ -221,7 +221,6 @@ kube-prometheus-stack:
     - daemonsets=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, giantswarm.io/monitoring_basic_sli, giantswarm.io/service-type]
     - deployments=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, giantswarm.io/monitoring_basic_sli, giantswarm.io/service-type]
     - nodes=[giantswarm.io/machine-pool, giantswarm.io/machine-deployment, ip, node.kubernetes.io/instance-type, topology.kubernetes.io/region, topology.kubernetes.io/zone]
-    - persistentvolumeclaims=[name]
     - pods=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, giantswarm.io/monitoring_basic_sli, giantswarm.io/service-type]
     - statefulsets=[application.giantswarm.io/team, app.kubernetes.io/name, app.kubernetes.io/component, app.kubernetes.io/instance, giantswarm.io/monitoring_basic_sli, giantswarm.io/service-type]
     networkPolicy:


### PR DESCRIPTION
This PR fixes the kube-state-metrics config to match with the value defined in vintage MCs https://github.com/giantswarm/shared-configs/blob/main/default/apps/observability-bundle/configmap-values.yaml.template.

It also removes the list of collectors as it is redundant with the default https://github.com/prometheus-community/helm-charts/blob/02e7a20e02bad8073172842cf871d437e7b4a6c4/charts/kube-state-metrics/values.yaml#L320


<!--
@team-atlas will be automatically requested for review once
this PR has been submitted.
-->
