### PR TITLE
Remove label for old slo framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
 - Upgraded chart dependency from kube-prometheus-stack-58.3.0 to [kube-prometheus-stack-58.3.1](https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-58.3.1)
 
+### Removed
+
+- Remove `giantswarm.io/monitoring_basic_sli` label on the prometheus operator to get rid of the old slo alert mechanism.
+
 ## [10.0.0] - 2024-04-30
+
+### Changed
 
 - Upgraded chart dependency to [kube-prometheus-stack-58.3.0](https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-58.3.0)
   - kube-state-metrics from 2.10.0 to [2.12.0](https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.12.0)

--- a/helm/kube-prometheus-stack/values.schema.json
+++ b/helm/kube-prometheus-stack/values.schema.json
@@ -180,12 +180,6 @@
                 "kube-state-metrics": {
                     "type": "object",
                     "properties": {
-                        "collectors": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
                         "image": {
                             "type": "object",
                             "properties": {
@@ -863,18 +857,18 @@
                         "enabled": {
                             "type": "boolean"
                         },
-                        "image": {
+                        "env": {
                             "type": "object",
                             "properties": {
-                                "repository": {
+                                "GOGC": {
                                     "type": "string"
                                 }
                             }
                         },
-                        "labels": {
+                        "image": {
                             "type": "object",
                             "properties": {
-                                "giantswarm.io/monitoring_basic_sli": {
+                                "repository": {
                                     "type": "string"
                                 }
                             }

--- a/helm/kube-prometheus-stack/values.yaml
+++ b/helm/kube-prometheus-stack/values.yaml
@@ -346,8 +346,6 @@ kube-prometheus-stack:
       cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     image:
       repository: giantswarm/prometheus-operator
-    labels:
-      giantswarm.io/monitoring_basic_sli: "true"
     prometheusConfigReloader:
       image:
         repository: giantswarm/prometheus-config-reloader


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3318

This PR removes the label used by the old slo framework in order to get rid of the old slo framework.

This will be turned into an availability slo for the prometheus operator in sloth-rules https://github.com/giantswarm/sloth-rules/pull/186
