### PR TITLE
Add link to full list of values

### DIFF
--- a/helm/kube-prometheus-stack/values.yaml
+++ b/helm/kube-prometheus-stack/values.yaml
@@ -11,6 +11,9 @@ kyvernoPolicyExceptions:
   namespace: giantswarm
 
 kube-prometheus-stack:
+  # Full list of values can be found at:
+  # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
+  # Note: make sure to add valus you want to override under the  `kube-prometheus-stack` key.
   alertmanager:
     alertmanagerSpec:
       image:

--- a/helm/kube-prometheus-stack/values.yaml
+++ b/helm/kube-prometheus-stack/values.yaml
@@ -13,7 +13,7 @@ kyvernoPolicyExceptions:
 kube-prometheus-stack:
   # Full list of values can be found at:
   # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
-  # Note: make sure to add valus you want to override under the  `kube-prometheus-stack` key.
+  # Note: make sure to add values you want to override under the `kube-prometheus-stack` key.
   alertmanager:
     alertmanagerSpec:
       image:


### PR DESCRIPTION
For convinience I added a link to the upstream values from within our
values.yaml

This helps in case one wants to know which values are available to
template the chart.


<!--
@team-atlas will be automatically requested for review once
this PR has been submitted.
-->