### PR TITLE
update kyverno policy exception version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update Kyverno PolicyExceptions to v2.
+
 ## [18.0.0] - 2025-08-26
 
 ### Changed

--- a/helm/kube-prometheus-stack/templates/prometheus-node-exporter/kyverno-policy-exception.yaml
+++ b/helm/kube-prometheus-stack/templates/prometheus-node-exporter/kyverno-policy-exception.yaml
@@ -1,6 +1,11 @@
 {{- if and .Values.kyvernoPolicyExceptions.enabled (index .Values "kube-prometheus-stack" "nodeExporter" "enabled") }}
-{{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" -}}
+{{- if .Capabilities.APIVersions.Has "kyverno.io/v2/PolicyException" -}}
+apiVersion: kyverno.io/v2
+{{- else if .Capabilities.APIVersions.Has "kyverno.io/v2beta1/PolicyException" -}}
+apiVersion: kyverno.io/v2beta1
+{{- else -}}
 apiVersion: kyverno.io/v2alpha1
+{{- end }}
 kind: PolicyException
 metadata:
   annotations:
@@ -49,5 +54,4 @@ spec:
         - {{ include "prometheus-node-exporter.namespace" . }}
         names:
         - {{ include "prometheus-node-exporter.fullname" . }}*
-  {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/34101

This pull request updates the handling of Kyverno PolicyExceptions in the chart to use the new v2 API version. This change ensures compatibility with the latest Kyverno release and improves future maintainability.